### PR TITLE
fix timeout unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.3
+VERSION=0.0.4
 LDFLAGS=-ldflags "-X main.Version=${VERSION}"
 
 all: mackerel-plugin-pinging

--- a/main.go
+++ b/main.go
@@ -66,14 +66,14 @@ func getStats(opts cmdOpts) error {
 	e := float64(0)
 
 	// preflight
-	_, err := pinger.Ping(ra, time.Duration(opts.Timeout))
+	_, err := pinger.Ping(ra, time.Millisecond * time.Duration(opts.Timeout))
 	if err != nil {
 		log.Printf("error in preflight: %v", err)
 	}
 
 	for i := 0; i < opts.Count; i++ {
 		time.Sleep(time.Millisecond * time.Duration(opts.Interval))
-		rtt, err := pinger.Ping(ra, time.Duration(opts.Timeout))
+		rtt, err := pinger.Ping(ra, time.Millisecond * time.Duration(opts.Timeout))
 		if err != nil {
 			log.Printf("%v", err)
 			e++


### PR DESCRIPTION
## WHY

ping check failed with default timeout

```
$ ping 8.8.8.8 -c 2
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=43 time=6.56 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=43 time=6.60 ms

--- 8.8.8.8 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 6.564/6.584/6.605/0.083 ms

/usr/local/bin/mackerel-plugin-pinging --host 8.8.8.8 --key-prefix google
2019/12/09 14:55:08 error in preflight: i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
2019/12/09 14:55:08 i/o timeout
pinging.google_rtt_count.success	0.000000	1575870908
pinging.google_rtt_count.error	10.000000	1575870908
```

## WHAT

add proper unit to the timeout setting